### PR TITLE
refactor: replace deprecated initializationOptions with initialization_options

### DIFF
--- a/LSP-cmake.sublime-settings
+++ b/LSP-cmake.sublime-settings
@@ -2,7 +2,7 @@
 	"command": [
 		"$server_path"
 	],
-	"initializationOptions": {
+	"initialization_options": {
 		"buildDirectory": "$folder/build"
 	},
 	"selector": "source.cmake"


### PR DESCRIPTION
In https://github.com/sublimelsp/LSP/releases/tag/4070-2.9.0 `config.init_options`
and `initializationOptions` in settings were deprecated.

(This is a semi-automatically created PR that might not
have been tested manually.)
