### PR TITLE
refactor: add ruff rules for sorting imports

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from lsp_utils.pip_client_handler import PipClientHandler
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,20 @@
-[tool.black]
+
+[tool.pyright]
+pythonVersion = "3.8"
+
+[tool.ruff]
 line-length = 120
-target-version = ['py33']
+target-version = "py38"
+
+[tool.ruff.lint]
+# Enable preview rules.
+preview = true
+select = ["F401", "I"]
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+from-first = true
+no-sections = true
+order-by-type = false
+required-imports = ["from __future__ import annotations"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [tool.pyright]
 pythonVersion = "3.8"
 


### PR DESCRIPTION
This is a semi-automatically created PR that adds ruff configuration for imports formatting.

It matches configuration included in the LSP package with the intention of consolidating import style across all LSP packages.

If you have strong preference to a different style, please keep the configuration but update it to your liking so that anyone working on the package does not have to guess the correct style to use. See [ruff isort settings](https://docs.astral.sh/ruff/settings/#lintisort).

(Since this PR was created semi-automatically, it might require some changes before being considered ready.)